### PR TITLE
Update EA references after org name change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,25 @@
 # Project application and funding (PAFS) tests
 
-[![Build Status](https://travis-ci.org/EnvironmentAgency/pafs-acceptance-tests.svg?branch=master)](https://travis-ci.org/EnvironmentAgency/pafs-acceptance-tests)
-[![security](https://hakiri.io/github/EnvironmentAgency/pafs-acceptance-tests/master.svg)](https://hakiri.io/github/EnvironmentAgency/pafs-acceptance-tests/master)
-[![Dependency Status](https://dependencyci.com/github/EnvironmentAgency/pafs-acceptance-tests/badge)](https://dependencyci.com/github/EnvironmentAgency/pafs-acceptance-tests)
+[![Build Status](https://travis-ci.org/DEFRA/pafs-acceptance-tests.svg?branch=master)](https://travis-ci.org/DEFRA/pafs-acceptance-tests)
+[![security](https://hakiri.io/github/DEFRA/pafs-acceptance-tests/master.svg)](https://hakiri.io/github/DEFRA/pafs-acceptance-tests/master)
+[![Dependency Status](https://dependencyci.com/github/DEFRA/pafs-acceptance-tests/badge)](https://dependencyci.com/github/DEFRA/pafs-acceptance-tests)
 
 The Project Application and Funding Service (PAFS) is used by regional management authorities to apply for funding for flood and coastal risk management projects.
 
-
-This project contains the acceptance tests for the service. It is built around [Quke](https://github.com/EnvironmentAgency/quke), a Ruby gem that simplifies the process of writing and running Cucumber acceptance tests.
+This project contains the acceptance tests for the service. It is built around [Quke](https://github.com/DEFRA/quke), a Ruby gem that simplifies the process of writing and running Cucumber acceptance tests.
 
 ## Pre-requisites
 
 This project is setup to run against version 2.3.0 of Ruby.
 
-The rest of the pre-requisites are the same as those for [Quke](https://github.com/EnvironmentAgency/quke#pre-requisites).
+The rest of the pre-requisites are the same as those for [Quke](https://github.com/DEFRA/quke#pre-requisites).
 
 ## Installation
 
 First clone the repository and then drop into your new local repo
 
 ```bash
-git clone https://github.com/EnvironmentAgency/pafs-acceptance-tests.git && cd pafs-acceptance-tests
+git clone https://github.com/DEFRA/pafs-acceptance-tests.git && cd pafs-acceptance-tests
 ```
 
 Next download and install the dependencies
@@ -31,7 +30,7 @@ bundle install
 
 ## Configuration
 
-You can figure how the project runs using [Quke config files](https://github.com/EnvironmentAgency/quke#configuration). Before executing this project for the first time you'll need to create an initial `.config.yml` file.
+You can figure how the project runs using [Quke config files](https://github.com/DEFRA/quke#configuration). Before executing this project for the first time you'll need to create an initial `.config.yml` file.
 
 ```bash
 touch .config.yml
@@ -61,7 +60,7 @@ Simply call
 bundle exec quke
 ```
 
-You can create [multiple config files](https://github.com/EnvironmentAgency/quke#multiple-configs), for example you may wish to have one setup for running against **Chrome**, and another to run against a different environment. You can tell **Quke** which config file to use by adding an environment variable argument to the command.
+You can create [multiple config files](https://github.com/DEFRA/quke#multiple-configs), for example you may wish to have one setup for running against **Chrome**, and another to run against a different environment. You can tell **Quke** which config file to use by adding an environment variable argument to the command.
 
 ```bash
 QUKE_CONFIG='chrome.config.yml' bundle exec quke

--- a/features/create_new_project.feature
+++ b/features/create_new_project.feature
@@ -8,7 +8,7 @@ Feature: Create a new project application
     Given I am an external user
       And I have a valid username and password
 
-  @happy_path
+  @happypath
   Scenario: Sumbmit a new proposal with Grant in Aid and Levy funding
     Given I create a new proposal
       And I request Grant in Aid funding
@@ -34,7 +34,7 @@ Feature: Create a new project application
 	   When I complete my proposal
      Then I should see that my proposal has been sent for review
 
-  @happy_path
+  @happypath
   Scenario: Created proposal is in draft status
     Given I create a new proposal
       And I request Grant in Aid funding


### PR DESCRIPTION
The Environment Agency organisation on GitHub recently changed its name to DEFRA. This has resulted in a change to all the urls for all our repos. This changes updates any references to the old repo url's for example

- in repo status badges
- links to other projects in the README