### PR TITLE
Add ability to set a custom window size

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,19 @@ Into that file you'll need to add the `app_host:` entry, with the url of the FRA
 
 If left as that by default when **Quke** is executed it will run against your selected environment using the headless browser **PhantomJS**.
 
+### Custom PAFS config
+
+Recently we have needed to add special logic for running the tests in Linux environments. When run on Linux tests are failing if the an element is 'off the page' i.e. you would need to scroll to interact with it. Because of this when running tests in a Linux environment e.g. Ubuntu you'll need to add the following to the `.config.yml` (the sizes can vary, but ensure its large enough for all elements on all pages to be visible).
+
+```yaml
+custom:
+  window_size:
+    width: 1000
+    height: 2000
+```
+
+The project now includes logic to look for this and if present will resize the window accordingly. Ideally this situation should be periodically tested to see if this workaround is still required.
+
 ### Back office
 
 The project contains logic to automatically determine the URL to the back office, by assuming `app_host:` is the front office URL for one of our standard environments (development, QA, pre-prod or production).

--- a/features/hooks/before.rb
+++ b/features/hooks/before.rb
@@ -1,0 +1,15 @@
+Before do
+  # As of 2017-10-30 it appears that tests do not complete in linux environments
+  # if an element is not visible on the page. This should not be a problem and
+  # cannot be replicated locally when running on OSX, however has been confirmed
+  # in our AWS environments and on local Ubuntu machines.
+  # Therefore we've added this functionality that looks for a custom
+  # window_size element on the config object and if present, sets the window
+  # size at the start of each test
+  if Quke::Quke.config.custom && Quke::Quke.config.custom["window_size"]
+    Capybara.current_session.current_window.resize_to(
+      Quke::Quke.config.custom["window_size"]["width"],
+      Quke::Quke.config.custom["window_size"]["height"]
+    )
+  end
+end


### PR DESCRIPTION
This change fixes an issue that now appears to be common when running on Linux as opposed to OSX.

If an element is not visible in the window then capybara can't find it so the test fails. If you run without setting a custom window size, you can get your tests to pass by manually resizing the window hence confirming this is the issue.

With this change you can now set a custom window size, that will be used across all tests.