### PR TITLE
Attempt to fix not working in Jenkins CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,13 +9,3 @@ gem "rubocop", require: false
 # Rake gives us the ability to create our own commands or 'tasks' for working
 # with quke.
 gem "rake"
-
-# We don't actually need a reference to chromedriver-helper for this project;
-# quke itself brings it in. However when CDH updated to 1.1.0 and this project
-# took the change (thanks to an automated PR from Deppbot) we found it would no
-# longer run in our dev, qa and pre-prod environments.
-# This is because the versions of chromedriver actually on our jenkins slave
-# the one referred to in this update are no longer the same.
-# Hence by referring to it here we can lock the version to one we know allows
-# this project to run in our environments.
-gem "chromedriver-helper", "1.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
-    archive-zip (0.7.0)
+    archive-zip (0.11.0)
       io-like (~> 0.3.0)
     ast (2.4.0)
     browserstack-local (1.3.0)
@@ -17,9 +17,9 @@ GEM
       xpath (>= 2.0, < 4.0)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
-    chromedriver-helper (1.0.0)
-      archive-zip (~> 0.7.0)
-      nokogiri (~> 1.6)
+    chromedriver-helper (1.2.0)
+      archive-zip (~> 0.10)
+      nokogiri (~> 1.8)
     cliver (0.3.2)
     cucumber (2.99.0)
       builder (>= 2.1.2)
@@ -100,7 +100,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  chromedriver-helper (= 1.0.0)
   quke
   rake
   rubocop


### PR DESCRIPTION
The error we are getting in Jenkins is

```
unable to connect to chromedriver 127.0.0.1:9515 (Selenium::WebDriver::Error::WebDriverError)
```

In previous services this has been because the version of chromedriver used by the project has become out of sync with the version on the Jenkins slave.

However for PAFS we checked the versions of Chrome and Chromedriver and found

- Chrome 66.0.3359.181
- Chromedriver 2.38.552522

At the time of writing this would indicate the slave is actually using the latest versions of everything.

Hence this change attempts to fix the issue by moving chromedriver-helper to the latest.