### PR TITLE
[PM-587] Correct ACP tests for new UI gem in PAFS

### DIFF
--- a/features/page_objects/confidence_homes_better_protected_page.rb
+++ b/features/page_objects/confidence_homes_better_protected_page.rb
@@ -2,11 +2,11 @@ class ConfidenceHomesBetterProtectedPage < SitePrism::Page
 
   section(:user_bar, AdminUserBarSection, AdminUserBarSection::SELECTOR)
 
-  element(:high, "#confidence_homes_better_protected_step_confidence_homes_better_protected_high")
-  element(:mednium_high, "#confidence_homes_better_protected_step_confidence_homes_better_protected_medium_high")
-  element(:medium_low, "#confidence_homes_better_protected_step_confidence_homes_better_protected_medium_low")
-  element(:low, "#confidence_homes_better_protected_step_confidence_homes_better_protected_low")
-  element(:not_applicable, "#confidence_homes_better_protected_step_confidence_homes_better_protected_not_applicable")
+  element(:high, "#confidence_homes_better_protected_step_confidence_homes_better_protected_high", visible: false)
+  element(:mednium_high, "#confidence_homes_better_protected_step_confidence_homes_better_protected_medium_high", visible: false)
+  element(:medium_low, "#confidence_homes_better_protected_step_confidence_homes_better_protected_medium_low", visible: false)
+  element(:low, "#confidence_homes_better_protected_step_confidence_homes_better_protected_low", visible: false)
+  element(:not_applicable, "#confidence_homes_better_protected_step_confidence_homes_better_protected_not_applicable", visible: false)
   element(:submit_button, "input[name='commit']")
 
   def submit(args = {})

--- a/features/page_objects/confidence_homes_better_protected_page.rb
+++ b/features/page_objects/confidence_homes_better_protected_page.rb
@@ -1,12 +1,16 @@
+# frozen_string_literal: true
+
 class ConfidenceHomesBetterProtectedPage < SitePrism::Page
 
   section(:user_bar, AdminUserBarSection, AdminUserBarSection::SELECTOR)
 
-  element(:high, "#confidence_homes_better_protected_step_confidence_homes_better_protected_high", visible: false)
-  element(:mednium_high, "#confidence_homes_better_protected_step_confidence_homes_better_protected_medium_high", visible: false)
-  element(:medium_low, "#confidence_homes_better_protected_step_confidence_homes_better_protected_medium_low", visible: false)
-  element(:low, "#confidence_homes_better_protected_step_confidence_homes_better_protected_low", visible: false)
-  element(:not_applicable, "#confidence_homes_better_protected_step_confidence_homes_better_protected_not_applicable", visible: false)
+  COMMON_SELECTOR = "confidence_homes_better_protected_step_confidence_homes_better_protected"
+
+  element(:high, "##{COMMON_SELECTOR}_high", visible: false)
+  element(:mednium_high, "##{COMMON_SELECTOR}_medium_high", visible: false)
+  element(:medium_low, "##{COMMON_SELECTOR}_medium_low", visible: false)
+  element(:low, "##{COMMON_SELECTOR}_low", visible: false)
+  element(:not_applicable, "##{COMMON_SELECTOR}_not_applicable", visible: false)
   element(:submit_button, "input[name='commit']")
 
   def submit(args = {})

--- a/features/page_objects/confidence_homes_by_gateway_four_page.rb
+++ b/features/page_objects/confidence_homes_by_gateway_four_page.rb
@@ -2,11 +2,11 @@ class ConfidenceHomesByGatewayFourPage < SitePrism::Page
 
   section(:user_bar, AdminUserBarSection, AdminUserBarSection::SELECTOR)
 
-  element(:high, "#confidence_homes_by_gateway_four_step_confidence_homes_by_gateway_four_high")
-  element(:mednium_high, "#confidence_homes_by_gateway_four_step_confidence_homes_by_gateway_four_medium_high")
-  element(:medium_low, "#confidence_homes_by_gateway_four_step_confidence_homes_by_gateway_four_medium_low")
-  element(:low, "#confidence_homes_by_gateway_four_step_confidence_homes_by_gateway_four_low")
-  element(:not_applicable, "#confidence_homes_by_gateway_four_step_confidence_homes_by_gateway_four_not_applicable")
+  element(:high, "#confidence_homes_by_gateway_four_step_confidence_homes_by_gateway_four_high", visible: false)
+  element(:mednium_high, "#confidence_homes_by_gateway_four_step_confidence_homes_by_gateway_four_medium_high", visible: false)
+  element(:medium_low, "#confidence_homes_by_gateway_four_step_confidence_homes_by_gateway_four_medium_low", visible: false)
+  element(:low, "#confidence_homes_by_gateway_four_step_confidence_homes_by_gateway_four_low", visible: false)
+  element(:not_applicable, "#confidence_homes_by_gateway_four_step_confidence_homes_by_gateway_four_not_applicable", visible: false)
   element(:submit_button, "input[name='commit']")
 
   def submit(args = {})

--- a/features/page_objects/confidence_homes_by_gateway_four_page.rb
+++ b/features/page_objects/confidence_homes_by_gateway_four_page.rb
@@ -1,12 +1,15 @@
+# frozen_string_literal: true
+
 class ConfidenceHomesByGatewayFourPage < SitePrism::Page
 
   section(:user_bar, AdminUserBarSection, AdminUserBarSection::SELECTOR)
 
-  element(:high, "#confidence_homes_by_gateway_four_step_confidence_homes_by_gateway_four_high", visible: false)
-  element(:mednium_high, "#confidence_homes_by_gateway_four_step_confidence_homes_by_gateway_four_medium_high", visible: false)
-  element(:medium_low, "#confidence_homes_by_gateway_four_step_confidence_homes_by_gateway_four_medium_low", visible: false)
-  element(:low, "#confidence_homes_by_gateway_four_step_confidence_homes_by_gateway_four_low", visible: false)
-  element(:not_applicable, "#confidence_homes_by_gateway_four_step_confidence_homes_by_gateway_four_not_applicable", visible: false)
+  COMMON_SELECTOR = "confidence_homes_by_gateway_four_step_confidence_homes_by_gateway_four"
+  element(:high, "##{COMMON_SELECTOR}_high", visible: false)
+  element(:mednium_high, "##{COMMON_SELECTOR}_medium_high", visible: false)
+  element(:medium_low, "##{COMMON_SELECTOR}_medium_low", visible: false)
+  element(:low, "##{COMMON_SELECTOR}_low", visible: false)
+  element(:not_applicable, "##{COMMON_SELECTOR}_not_applicable", visible: false)
   element(:submit_button, "input[name='commit']")
 
   def submit(args = {})

--- a/features/page_objects/confidence_secured_partnership_funding_page.rb
+++ b/features/page_objects/confidence_secured_partnership_funding_page.rb
@@ -2,11 +2,11 @@ class ConfidenceSecuredPartnershipFundingPage < SitePrism::Page
 
   section(:user_bar, AdminUserBarSection, AdminUserBarSection::SELECTOR)
   # rubocop:disable Metrics/LineLength
-  element(:high, "#confidence_secured_partnership_funding_step_confidence_secured_partnership_funding_high")
-  element(:mednium_high, "#confidence_secured_partnership_funding_step_confidence_secured_partnership_funding_medium_high")
-  element(:medium_low, "#confidence_secured_partnership_funding_step_confidence_secured_partnership_funding_medium_low")
-  element(:low, "#confidence_secured_partnership_funding_step_confidence_secured_partnership_funding_low")
-  element(:not_applicable, "#confidence_secured_partnership_funding_step_confidence_secured_partnership_funding_not_applicable")
+  element(:high, "#confidence_secured_partnership_funding_step_confidence_secured_partnership_funding_high", visible: false)
+  element(:mednium_high, "#confidence_secured_partnership_funding_step_confidence_secured_partnership_funding_medium_high", visible: false)
+  element(:medium_low, "#confidence_secured_partnership_funding_step_confidence_secured_partnership_funding_medium_low", visible: false)
+  element(:low, "#confidence_secured_partnership_funding_step_confidence_secured_partnership_funding_low", visible: false)
+  element(:not_applicable, "#confidence_secured_partnership_funding_step_confidence_secured_partnership_funding_not_applicable", visible: false)
   element(:submit_button, "input[name='commit']")
   # rubocop:enable Metrics/LineLength
 

--- a/features/page_objects/earliest_start_page.rb
+++ b/features/page_objects/earliest_start_page.rb
@@ -2,8 +2,8 @@ class EarliestStartPage < SitePrism::Page
 
   section(:user_bar, AdminUserBarSection, AdminUserBarSection::SELECTOR)
 
-  element(:start_sooner_yes, "#earliest_start_step_could_start_early_true")
-  element(:start_sooner_no, "#earliest_start_step_could_start_early_false")
+  element(:start_sooner_yes, "#earliest_start_step_could_start_early_true", vidible: false)
+  element(:start_sooner_no, "#earliest_start_step_could_start_early_false", vidible: false)
 
   element(:submit_button, "input[name='commit']")
 

--- a/features/page_objects/earliest_start_page.rb
+++ b/features/page_objects/earliest_start_page.rb
@@ -2,8 +2,8 @@ class EarliestStartPage < SitePrism::Page
 
   section(:user_bar, AdminUserBarSection, AdminUserBarSection::SELECTOR)
 
-  element(:start_sooner_yes, "#earliest_start_step_could_start_early_true", vidible: false)
-  element(:start_sooner_no, "#earliest_start_step_could_start_early_false", vidible: false)
+  element(:start_sooner_yes, "#earliest_start_step_could_start_early_true", visible: false)
+  element(:start_sooner_no, "#earliest_start_step_could_start_early_false", visible: false)
 
   element(:submit_button, "input[name='commit']")
 

--- a/features/page_objects/environmental_outcomes_page.rb
+++ b/features/page_objects/environmental_outcomes_page.rb
@@ -2,8 +2,8 @@ class EnvironmentalOutcomesPage < SitePrism::Page
 
   section(:user_bar, AdminUserBarSection, AdminUserBarSection::SELECTOR)
 
-  element(:improve_yes, "#surface_and_groundwater_step_improve_surface_or_groundwater_true")
-  element(:improve_no, "#surface_and_groundwater_step_improve_surface_or_groundwater_false")
+  element(:improve_yes, "#surface_and_groundwater_step_improve_surface_or_groundwater_true", visible: false)
+  element(:improve_no, "#surface_and_groundwater_step_improve_surface_or_groundwater_false", visible: false)
 
   element(:submit_button, "input[name='commit']")
 

--- a/features/page_objects/flood_protection_outcomes_page.rb
+++ b/features/page_objects/flood_protection_outcomes_page.rb
@@ -24,7 +24,7 @@ class FloodProtectionOutcomesPage < SitePrism::Page
   element(:c5, "#flood_protection_outcomes_step_flood_protection_outcomes_attributes_4_households_protected_from_loss_in_20_percent_most_deprived")
   element(:c6, "#flood_protection_outcomes_step_flood_protection_outcomes_attributes_5_households_protected_from_loss_in_20_percent_most_deprived")
 
-  element(:select_none, "#flood_protection_outcomes_step_reduced_risk_of_households_for_floods")
+  element(:select_none, "#flood_protection_outcomes_step_reduced_risk_of_households_for_floods", visible: false)
 
   element(:submit_button, "input[name='commit']")
   # There is no value in attempting to break up this method, it would only make

--- a/features/page_objects/funding_sources_page.rb
+++ b/features/page_objects/funding_sources_page.rb
@@ -2,16 +2,16 @@ class FundingSourcesPage < SitePrism::Page
 
   section(:user_bar, AdminUserBarSection, AdminUserBarSection::SELECTOR)
 
-  element(:grant_in_aid, "#funding_sources_step_fcerm_gia")
-  element(:local_levy, "#funding_sources_step_local_levy")
-  element(:public_sector, "#funding_sources_step_public_contributions")
-  element(:private_sector, "#funding_sources_step_private_contributions")
-  element(:ea_contributions, "#funding_sources_step_other_ea_contributions")
-  element(:growth_funding, "#funding_sources_step_growth_funding")
-  element(:drainage_board, "#funding_sources_step_internal_drainage_boards")
-  element(:other, "#funding_sources_step_not_yet_identified")
+  element(:grant_in_aid, "#funding_sources_step_fcerm_gia", visible: false)
+  element(:local_levy, "#funding_sources_step_local_levy", visible: false)
+  element(:public_sector, "#funding_sources_step_public_contributions", visible: false)
+  element(:private_sector, "#funding_sources_step_private_contributions", visible: false)
+  element(:ea_contributions, "#funding_sources_step_other_ea_contributions", visible: false)
+  element(:growth_funding, "#funding_sources_step_growth_funding", visible: false)
+  element(:drainage_board, "#funding_sources_step_internal_drainage_boards", visible: false)
+  element(:other, "#funding_sources_step_not_yet_identified", visible: false)
 
-  elements(:sources, "input[type='checkbox']")
+  elements(:sources, "input[type='checkbox']", visible: false)
 
   element(:submit_button, "input[name='commit']")
 

--- a/features/page_objects/habitat_creation_page.rb
+++ b/features/page_objects/habitat_creation_page.rb
@@ -2,8 +2,8 @@ class HabitatCreationPage < SitePrism::Page
 
   section(:user_bar, AdminUserBarSection, AdminUserBarSection::SELECTOR)
 
-  element(:create_yes, "#habitat_creation_step_create_habitat_true")
-  element(:create_no, "#habitat_creation_step_create_habitat_false")
+  element(:create_yes, "#habitat_creation_step_create_habitat_true", visible: false)
+  element(:create_no, "#habitat_creation_step_create_habitat_false", visible: false)
 
   element(:submit_button, "input[name='commit']")
 

--- a/features/page_objects/improve_hpi_page.rb
+++ b/features/page_objects/improve_hpi_page.rb
@@ -2,8 +2,8 @@ class ImproveHbiPage < SitePrism::Page
 
   section(:user_bar, AdminUserBarSection, AdminUserBarSection::SELECTOR)
 
-  element(:improve_yes, "#improve_hpi_step_improve_hpi_true")
-  element(:improve_no, "#improve_hpi_step_improve_hpi_false")
+  element(:improve_yes, "#improve_hpi_step_improve_hpi_true", visible: false)
+  element(:improve_no, "#improve_hpi_step_improve_hpi_false", visible: false)
 
   element(:submit_button, "input[name='commit']")
 

--- a/features/page_objects/improve_river_page.rb
+++ b/features/page_objects/improve_river_page.rb
@@ -2,8 +2,8 @@ class ImproveRiverPage < SitePrism::Page
 
   section(:user_bar, AdminUserBarSection, AdminUserBarSection::SELECTOR)
 
-  element(:improve_yes, "#improve_river_step_improve_river_true")
-  element(:improve_no, "#improve_river_step_improve_river_false")
+  element(:improve_yes, "#improve_river_step_improve_river_true", visible: false)
+  element(:improve_no, "#improve_river_step_improve_river_false", visible: false)
 
   element(:submit_button, "input[name='commit']")
 

--- a/features/page_objects/improve_spa_or_sac_page.rb
+++ b/features/page_objects/improve_spa_or_sac_page.rb
@@ -2,8 +2,8 @@ class ImproveSpaOrSacPage < SitePrism::Page
 
   section(:user_bar, AdminUserBarSection, AdminUserBarSection::SELECTOR)
 
-  element(:improve_yes, "#improve_spa_or_sac_step_improve_spa_or_sac_true")
-  element(:improve_no, "#improve_spa_or_sac_step_improve_spa_or_sac_false")
+  element(:improve_yes, "#improve_spa_or_sac_step_improve_spa_or_sac_true", visible: false)
+  element(:improve_no, "#improve_spa_or_sac_step_improve_spa_or_sac_false", visible: false)
 
   element(:submit_button, "input[name='commit']")
 

--- a/features/page_objects/improve_sssi_page.rb
+++ b/features/page_objects/improve_sssi_page.rb
@@ -2,8 +2,8 @@ class ImproveSssiPage < SitePrism::Page
 
   section(:user_bar, AdminUserBarSection, AdminUserBarSection::SELECTOR)
 
-  element(:improve_yes, "#improve_sssi_step_improve_sssi_true")
-  element(:improve_no, "#improve_sssi_step_improve_sssi_false")
+  element(:improve_yes, "#improve_sssi_step_improve_sssi_true", visible: false)
+  element(:improve_no, "#improve_sssi_step_improve_sssi_false", visible: false)
 
   element(:submit_button, "input[name='commit']")
 

--- a/features/page_objects/new_funding_calculator_page.rb
+++ b/features/page_objects/new_funding_calculator_page.rb
@@ -2,8 +2,8 @@ class NewFundingCalculatorPage < SitePrism::Page
 
   section(:user_bar, AdminUserBarSection, AdminUserBarSection::SELECTOR)
 
-  element(:radio_Yes, "#funding_calculator_step_expected_version_v9")
-  element(:radio_No, "#funding_calculator_step_expected_version_v8")
+  element(:radio_Yes, "#funding_calculator_step_expected_version_v9", visible: false)
+  element(:radio_No, "#funding_calculator_step_expected_version_v8", visible: false)
   element(:choose_file, "#funding_calculator_step_funding_calculator")
   element(:submit_button, "input[name='commit']")
 

--- a/features/page_objects/new_funding_sources_page.rb
+++ b/features/page_objects/new_funding_sources_page.rb
@@ -2,16 +2,16 @@ class NewFundingSourcesPage < SitePrism::Page
 
   section(:user_bar, AdminUserBarSection, AdminUserBarSection::SELECTOR)
 
-  element(:grant_in_aid, "#funding_sources_step_fcerm_gia")
-  element(:local_levy, "#funding_sources_step_local_levy")
-  element(:public_sector, "#funding_sources_step_public_contributions")
-  element(:private_sector, "#funding_sources_step_private_contributions")
-  element(:ea_contributions, "#funding_sources_step_other_ea_contributions")
-  element(:growth_funding, "#funding_sources_step_growth_funding")
-  element(:drainage_board, "#funding_sources_step_internal_drainage_boards")
-  element(:other, "#funding_sources_step_not_yet_identified")
+  element(:grant_in_aid, "#funding_sources_step_fcerm_gia", visible: false)
+  element(:local_levy, "#funding_sources_step_local_levy", visible: false)
+  element(:public_sector, "#funding_sources_step_public_contributions", visible: false)
+  element(:private_sector, "#funding_sources_step_private_contributions", visible: false)
+  element(:ea_contributions, "#funding_sources_step_other_ea_contributions", visible: false)
+  element(:growth_funding, "#funding_sources_step_growth_funding", visible: false)
+  element(:drainage_board, "#funding_sources_step_internal_drainage_boards", visible: false)
+  element(:other, "#funding_sources_step_not_yet_identified", visible: false)
 
-  elements(:sources, "input[type='checkbox']")
+  elements(:sources, "input[type='checkbox']", visible: false)
 
   element(:submit_button, "input[name='commit']")
 

--- a/features/page_objects/project_type_page.rb
+++ b/features/page_objects/project_type_page.rb
@@ -2,13 +2,13 @@ class ProjectTypePage < SitePrism::Page
 
   section(:user_bar, AdminUserBarSection, AdminUserBarSection::SELECTOR)
 
-  element(:defence, "#project_type_step_project_type_def")
-  element(:cm, "#project_type_step_project_type_cm")
-  element(:plp, "#project_type_step_project_type_plp")
-  element(:brg, "#project_type_step_project_type_brg")
-  element(:str, "#project_type_step_project_type_str")
-  element(:households_yes, "#project_type_step_project_type_env_with_households")
-  element(:households_no, "#project_type_step_project_type_env_without_households")
+  element(:defence, "#project_type_step_project_type_def", visible: false)
+  element(:cm, "#project_type_step_project_type_cm", visible: false)
+  element(:plp, "#project_type_step_project_type_plp", visible: false)
+  element(:brg, "#project_type_step_project_type_brg", visible: false)
+  element(:str, "#project_type_step_project_type_str", visible: false)
+  element(:households_yes, "#project_type_step_project_type_env_with_households", visible: false)
+  element(:households_no, "#project_type_step_project_type_env_without_households", visible: false)
 
   element(:submit_button, "input[name='commit']")
 

--- a/features/page_objects/project_year_page.rb
+++ b/features/page_objects/project_year_page.rb
@@ -2,12 +2,12 @@ class ProjectYearPage < SitePrism::Page
 
   section(:user_bar, AdminUserBarSection, AdminUserBarSection::SELECTOR)
 
-  element(:april_2016_March_2017, "#financial_year_step_project_end_financial_year_2016")
-  element(:april_2017_March_2018, "#financial_year_step_project_end_financial_year_2017")
-  element(:april_2018_March_2019, "#financial_year_step_project_end_financial_year_2018")
-  element(:april_2019_March_2020, "#financial_year_step_project_end_financial_year_2019")
-  element(:april_2020_March_2021, "#financial_year_step_project_end_financial_year_2020")
-  element(:april_2021_March_2022, "#financial_year_step_project_end_financial_year_2021")
+  element(:april_2016_March_2017, "#financial_year_step_project_end_financial_year_2016", visible: false)
+  element(:april_2017_March_2018, "#financial_year_step_project_end_financial_year_2017", visible: false)
+  element(:april_2018_March_2019, "#financial_year_step_project_end_financial_year_2018", visible: false)
+  element(:april_2019_March_2020, "#financial_year_step_project_end_financial_year_2019", visible: false)
+  element(:april_2020_March_2021, "#financial_year_step_project_end_financial_year_2020", visible: false)
+  element(:april_2021_March_2022, "#financial_year_step_project_end_financial_year_2021", visible: false)
 
   # href that ends with financial_year_alternative
   element(:after_2020, "a[href$='financial_year_alternative']")

--- a/features/page_objects/remove_eel_barrier_page.rb
+++ b/features/page_objects/remove_eel_barrier_page.rb
@@ -2,8 +2,8 @@ class RemoveEelBarrierPage < SitePrism::Page
 
   section(:user_bar, AdminUserBarSection, AdminUserBarSection::SELECTOR)
 
-  element(:remove_yes, "#remove_eel_barrier_step_remove_eel_barrier_true")
-  element(:remove_no, "#remove_eel_barrier_step_remove_eel_barrier_false")
+  element(:remove_yes, "#remove_eel_barrier_step_remove_eel_barrier_true", visible: false)
+  element(:remove_no, "#remove_eel_barrier_step_remove_eel_barrier_false", visible: false)
 
   element(:submit_button, "input[name='commit']")
 

--- a/features/page_objects/remove_fish_barrier_page.rb
+++ b/features/page_objects/remove_fish_barrier_page.rb
@@ -2,8 +2,8 @@ class RemoveFishBarrierPage < SitePrism::Page
 
   section(:user_bar, AdminUserBarSection, AdminUserBarSection::SELECTOR)
 
-  element(:remove_yes, "#remove_fish_barrier_step_remove_fish_barrier_true")
-  element(:remove_no, "#remove_fish_barrier_step_remove_fish_barrier_false")
+  element(:remove_yes, "#remove_fish_barrier_step_remove_fish_barrier_true", visible: false)
+  element(:remove_no, "#remove_fish_barrier_step_remove_fish_barrier_false", visible: false)
 
   element(:submit_button, "input[name='commit']")
 

--- a/features/page_objects/risks_page.rb
+++ b/features/page_objects/risks_page.rb
@@ -2,7 +2,7 @@ class RisksPage < SitePrism::Page
 
   section(:user_bar, AdminUserBarSection, AdminUserBarSection::SELECTOR)
 
-  elements(:sources, "input[type='checkbox']")
+  elements(:sources, "input[type='checkbox']", visible: false)
   element(:submit_button, "input[name='commit']")
 
   def submit(args = {})

--- a/features/page_objects/standard_of_protection_after_page.rb
+++ b/features/page_objects/standard_of_protection_after_page.rb
@@ -2,10 +2,10 @@ class StandardOfProtectionAfterPage < SitePrism::Page
 
   section(:user_bar, AdminUserBarSection, AdminUserBarSection::SELECTOR)
 
-  element(:very_significant, "#standard_of_protection_after_step_flood_protection_after_0")
-  element(:significant, "#standard_of_protection_after_step_flood_protection_after_1")
-  element(:moderate, "#standard_of_protection_after_step_flood_protection_after_2")
-  element(:low, "#standard_of_protection_after_step_flood_protection_after_3")
+  element(:very_significant, "#standard_of_protection_after_step_flood_protection_after_0", visible: false)
+  element(:significant, "#standard_of_protection_after_step_flood_protection_after_1", visible: false)
+  element(:moderate, "#standard_of_protection_after_step_flood_protection_after_2", visible: false)
+  element(:low, "#standard_of_protection_after_step_flood_protection_after_3", visible: false)
 
   element(:submit_button, "input[name='commit']")
 

--- a/features/page_objects/standard_of_protection_after_page.rb
+++ b/features/page_objects/standard_of_protection_after_page.rb
@@ -1,11 +1,14 @@
+# frozen_string_literal: true
+
 class StandardOfProtectionAfterPage < SitePrism::Page
 
   section(:user_bar, AdminUserBarSection, AdminUserBarSection::SELECTOR)
 
-  element(:very_significant, "#standard_of_protection_after_step_flood_protection_after_0", visible: false)
-  element(:significant, "#standard_of_protection_after_step_flood_protection_after_1", visible: false)
-  element(:moderate, "#standard_of_protection_after_step_flood_protection_after_2", visible: false)
-  element(:low, "#standard_of_protection_after_step_flood_protection_after_3", visible: false)
+  COMMON_SELECTOR = "standard_of_protection_after_step_flood_protection_after"
+  element(:very_significant, "##{COMMON_SELECTOR}_0", visible: false)
+  element(:significant, "##{COMMON_SELECTOR}_1", visible: false)
+  element(:moderate, "##{COMMON_SELECTOR}_2", visible: false)
+  element(:low, "##{COMMON_SELECTOR}_3", visible: false)
 
   element(:submit_button, "input[name='commit']")
 

--- a/features/page_objects/standard_of_protection_coastal_after_page.rb
+++ b/features/page_objects/standard_of_protection_coastal_after_page.rb
@@ -1,11 +1,14 @@
+# frozen_string_literal: true
+
 class StandardOfProtectionCoastalAfterPage < SitePrism::Page
 
   section(:user_bar, AdminUserBarSection, AdminUserBarSection::SELECTOR)
 
-  element(:less_that_ten_years, "#standard_of_protection_coastal_after_step_coastal_protection_after_0", visible: false)
-  element(:ten_to_nighteen_years, "#standard_of_protection_coastal_after_step_coastal_protection_after_1", visible: false)
-  element(:twenty_to_fourtynine_years, "#standard_of_protection_coastal_after_step_coastal_protection_after_2", visible: false)
-  element(:fifty_years_or_more, "#standard_of_protection_coastal_after_step_coastal_protection_after_3", visible: false)
+  COMMON_SELECTOR = "standard_of_protection_coastal_after_step_coastal_protection_after"
+  element(:less_that_ten_years, "##{COMMON_SELECTOR}_0", visible: false)
+  element(:ten_to_nighteen_years, "##{COMMON_SELECTOR}_1", visible: false)
+  element(:twenty_to_fourtynine_years, "##{COMMON_SELECTOR}_2", visible: false)
+  element(:fifty_years_or_more, "##{COMMON_SELECTOR}_3", visible: false)
 
   element(:submit_button, "input[name='commit']")
 

--- a/features/page_objects/standard_of_protection_coastal_after_page.rb
+++ b/features/page_objects/standard_of_protection_coastal_after_page.rb
@@ -2,10 +2,10 @@ class StandardOfProtectionCoastalAfterPage < SitePrism::Page
 
   section(:user_bar, AdminUserBarSection, AdminUserBarSection::SELECTOR)
 
-  element(:less_that_ten_years, "#standard_of_protection_coastal_after_step_coastal_protection_after_0")
-  element(:ten_to_nighteen_years, "#standard_of_protection_coastal_after_step_coastal_protection_after_1")
-  element(:twenty_to_fourtynine_years, "#standard_of_protection_coastal_after_step_coastal_protection_after_2")
-  element(:fifty_years_or_more, "#standard_of_protection_coastal_after_step_coastal_protection_after_3")
+  element(:less_that_ten_years, "#standard_of_protection_coastal_after_step_coastal_protection_after_0", visible: false)
+  element(:ten_to_nighteen_years, "#standard_of_protection_coastal_after_step_coastal_protection_after_1", visible: false)
+  element(:twenty_to_fourtynine_years, "#standard_of_protection_coastal_after_step_coastal_protection_after_2", visible: false)
+  element(:fifty_years_or_more, "#standard_of_protection_coastal_after_step_coastal_protection_after_3", visible: false)
 
   element(:submit_button, "input[name='commit']")
 

--- a/features/page_objects/standard_of_protection_coastal_before_page.rb
+++ b/features/page_objects/standard_of_protection_coastal_before_page.rb
@@ -2,10 +2,10 @@ class StandardOfProtectionCoastalBeforePage < SitePrism::Page
 
   section(:user_bar, AdminUserBarSection, AdminUserBarSection::SELECTOR)
 
-  element(:less_that_one_year, "#standard_of_protection_coastal_step_coastal_protection_before_0")
-  element(:one_to_four_years, "#standard_of_protection_coastal_step_coastal_protection_before_1")
-  element(:five_to_nine_years, "#standard_of_protection_coastal_step_coastal_protection_before_2")
-  element(:ten_years_or_more, "#standard_of_protection_coastal_step_coastal_protection_before_3")
+  element(:less_that_one_year, "#standard_of_protection_coastal_step_coastal_protection_before_0", visible: false)
+  element(:one_to_four_years, "#standard_of_protection_coastal_step_coastal_protection_before_1", visible: false)
+  element(:five_to_nine_years, "#standard_of_protection_coastal_step_coastal_protection_before_2", visible: false)
+  element(:ten_years_or_more, "#standard_of_protection_coastal_step_coastal_protection_before_3", visible: false)
 
   element(:submit_button, "input[name='commit']")
 

--- a/features/page_objects/standard_of_protection_page.rb
+++ b/features/page_objects/standard_of_protection_page.rb
@@ -2,10 +2,10 @@ class StandardOfProtectionPage < SitePrism::Page
 
   section(:user_bar, AdminUserBarSection, AdminUserBarSection::SELECTOR)
 
-  element(:very_significant, "#standard_of_protection_step_flood_protection_before_0")
-  element(:significant, "#standard_of_protection_step_flood_protection_before_1")
-  element(:moderate, "#standard_of_protection_step_flood_protection_before_2")
-  element(:low, "#standard_of_protection_step_flood_protection_before_3")
+  element(:very_significant, "#standard_of_protection_step_flood_protection_before_0", visible: false)
+  element(:significant, "#standard_of_protection_step_flood_protection_before_1", visible: false)
+  element(:moderate, "#standard_of_protection_step_flood_protection_before_2", visible: false)
+  element(:low, "#standard_of_protection_step_flood_protection_before_3", visible: false)
 
   element(:submit_button, "input[name='commit']")
 

--- a/features/page_objects/urgency_page.rb
+++ b/features/page_objects/urgency_page.rb
@@ -2,12 +2,12 @@ class UrgencyPage < SitePrism::Page
 
   section(:user_bar, AdminUserBarSection, AdminUserBarSection::SELECTOR)
 
-  element(:nu, "#urgency_step_urgency_reason_not_urgent")
-  element(:stat, "#urgency_step_urgency_reason_statutory_need")
-  element(:legal, "#urgency_step_urgency_reason_legal_need")
-  element(:hs, "#urgency_step_urgency_reason_health_and_safety")
-  element(:emer, "#urgency_step_urgency_reason_emergency_works")
-  element(:time, "#urgency_step_urgency_reason_time_limited")
+  element(:nu, "#urgency_step_urgency_reason_not_urgent", visible: false)
+  element(:stat, "#urgency_step_urgency_reason_statutory_need", visible: false)
+  element(:legal, "#urgency_step_urgency_reason_legal_need", visible: false)
+  element(:hs, "#urgency_step_urgency_reason_health_and_safety", visible: false)
+  element(:emer, "#urgency_step_urgency_reason_emergency_works", visible: false)
+  element(:time, "#urgency_step_urgency_reason_time_limited", visible: false)
 
   element(:submit_button, "input[name='commit']")
 


### PR DESCRIPTION
* Radio buttons and checkboxes use CSS that hides the input element.
This fixes the capybara lookup to consider hidden elements too.